### PR TITLE
Indexed PAF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -538,6 +539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,18 +604,18 @@ dependencies = [
 
 [[package]]
 name = "noodles"
-version = "0.87.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af819286693ced8c3d26c0bb1c84473767e48489fe1d75c8563966fb1c9fe08"
+checksum = "cf45cb96fcf58766008616b1372e523f5402c0fa3e692734ef64ea60fa912bf3"
 dependencies = [
  "noodles-bgzf",
 ]
 
 [[package]]
 name = "noodles-bgzf"
-version = "0.34.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e624384981e5847bfd6a026f157c45d687187c30ee21b8c435310267c7aa7ab"
+checksum = "bb4a45ef5a49e622bcd33cbf9a8323ad3c2b8dd2395526354bc901983295fcf8"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1112,3 +1122,9 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bio-types"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +94,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -165,6 +180,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -569,6 +593,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "noodles"
+version = "0.87.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af819286693ced8c3d26c0bb1c84473767e48489fe1d75c8563966fb1c9fe08"
+dependencies = [
+ "noodles-bgzf",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e624384981e5847bfd6a026f157c45d687187c30ee21b8c435310267c7aa7ab"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,14 +623,17 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 name = "pafchainer"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "clap",
  "env_logger",
  "flate2",
  "lib_wfa2",
  "libc",
  "log",
+ "noodles",
  "rayon",
  "rust-htslib",
+ "serde",
  "thiserror 2.0.12",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,20 +6,20 @@ authors = ["Andrea Guarracino <aguarra1@uthsc.edu>"]
 description = "A tool to process PAF files and connect chains using WFA2 alignment"
 
 [dependencies]
-clap = { version = "4.5.31", features = ["derive"] }
+clap = { version = "4.5.34", features = ["derive"] }
 rust-htslib = { version = "0.46.0", default-features = false } # Don't update it, see https://github.com/rust-bio/rust-htslib/issues/434
 flate2 = "1.1.0"
 
 #lib_wfa2 = { path = "/home/guarracino/Dropbox/git/lib_wfa2"}
 lib_wfa2 = { git = "https://github.com/AndreaGuarracino/lib_wfa2", rev = "c608c436a6753d2c21c97d9f5c338efae99d042b"}
 
-log = "0.4.22"
-env_logger = "0.11.5"
+log = "0.4.27"
+env_logger = "0.11.7"
 
 rayon = "1.10.0" # Parallel processing library
 
-thiserror = "2.0.11"
-libc = "0.2"
-noodles = { version = "0.87.0", features = ["bgzf"] }
-serde = { version = "1.0.216", features = ["derive"] }
+thiserror = "2.0.12"
+libc = "0.2.171"
+noodles = { version = "0.95.0", features = ["bgzf"] }
+serde = { version = "1.0.219", features = ["derive"] }
 bincode = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ rayon = "1.10.0" # Parallel processing library
 
 thiserror = "2.0.11"
 libc = "0.2"
+noodles = { version = "0.87.0", features = ["bgzf"] }
+serde = { version = "1.0.216", features = ["derive"] }
+bincode = "1.3.3"

--- a/src/chain_index.rs
+++ b/src/chain_index.rs
@@ -1,0 +1,357 @@
+use log::{debug, info};
+use noodles::bgzf;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::error::Error;
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::Path;
+
+// PAF entry representation
+#[derive(Debug, Clone)]
+pub struct PafEntry {
+    pub query_name: String,
+    pub query_length: u64,
+    pub query_start: u64,
+    pub query_end: u64,
+    pub strand: char,
+    pub target_name: String,
+    pub target_length: u64,
+    pub target_start: u64,
+    pub target_end: u64,
+    pub num_matches: u64,
+    pub alignment_length: u64,
+    pub mapping_quality: u64,
+    pub tags: Vec<(String, String)>,
+    pub chain_id: u64,
+    pub chain_length: u64,
+    pub chain_pos: u64,
+    pub cigar: String,
+}
+
+impl PafEntry {
+    // Parse a PAF entry from a line
+    pub fn parse_from_line(line: &str) -> Result<Self, Box<dyn Error>> {
+        let fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() < 12 {
+            return Err("PAF line has fewer than 12 required fields".into());
+        }
+
+        let mut entry = PafEntry {
+            query_name: fields[0].to_string(),
+            query_length: fields[1].parse()?,
+            query_start: fields[2].parse()?,
+            query_end: fields[3].parse()?,
+            strand: if fields[4] == "+" { '+' } else { '-' },
+            target_name: fields[5].to_string(),
+            target_length: fields[6].parse()?,
+            target_start: fields[7].parse()?,
+            target_end: fields[8].parse()?,
+            num_matches: fields[9].parse()?,
+            alignment_length: fields[10].parse()?,
+            mapping_quality: fields[11].parse()?,
+            tags: Vec::new(),
+            chain_id: 0,
+            chain_length: 0,
+            chain_pos: 0,
+            cigar: String::new(),
+        };
+
+        // Parse optional tags
+        for i in 12..fields.len() {
+            let tag_parts: Vec<&str> = fields[i].split(':').collect();
+            if tag_parts.len() >= 3 {
+                let tag_name = format!("{}:{}", tag_parts[0], tag_parts[1]);
+                let tag_value = tag_parts[2..].join(":");
+
+                // Parse chain information
+                if tag_name == "ch:Z" {
+                    let chain_parts: Vec<&str> = tag_value.split('.').collect();
+                    if chain_parts.len() >= 3 {
+                        entry.chain_id = chain_parts[0].parse()?;
+                        entry.chain_length = chain_parts[1].parse()?;
+                        entry.chain_pos = chain_parts[2].parse()?;
+                    } else {
+                        return Err(format!("Invalid ch:Z tag format: {}", tag_value).into());
+                    }
+                }
+
+                // Parse CIGAR string
+                if tag_name == "cg:Z" {
+                    entry.cigar = tag_value.clone();
+                }
+
+                entry.tags.push((tag_name, tag_value));
+            }
+        }
+
+        // Verify required tags
+        if entry.chain_id == 0 || entry.cigar.is_empty() {
+            return Err("Missing required 'ch:Z' or 'cg:Z' tag".into());
+        }
+
+        Ok(entry)
+    }
+
+    // Convert PAF entry to string
+    pub fn to_string(&self) -> String {
+        let mut line = format!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            self.query_name,
+            self.query_length,
+            self.query_start,
+            self.query_end,
+            if self.strand == '+' { "+" } else { "-" },
+            self.target_name,
+            self.target_length,
+            self.target_start,
+            self.target_end,
+            self.num_matches,
+            self.alignment_length,
+            self.mapping_quality
+        );
+
+        // Add tags
+        for (tag, value) in &self.tags {
+            line.push_str(&format!("\t{}:{}", tag, value));
+        }
+
+        line
+    }
+}
+
+/// Represents a single entry within a chain
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ChainEntryInfo {
+    /// File offset (uncompressed for BGZF files)
+    pub offset: u64,
+    /// Length of the entry in bytes (including newline)
+    pub length: usize,
+    /// Position in the chain
+    pub chain_pos: u64,
+}
+
+/// Index structure for efficient processing of PAF chains
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ChainIndex {
+    /// Maps chain_id to a vector of file offsets
+    pub chains: HashMap<u64, Vec<ChainEntryInfo>>,
+    /// Path to the PAF file
+    pub paf_file: String,
+    /// Whether the PAF file is compressed
+    pub is_compressed: bool,
+}
+
+impl ChainIndex {
+    /// Build an index from a PAF file
+    pub fn build<P: AsRef<Path>>(paf_file: P) -> Result<Self, Box<dyn Error>> {
+        let paf_path = paf_file.as_ref();
+        let paf_str = paf_path.to_string_lossy().to_string();
+        let is_compressed = [".gz", ".bgz"].iter().any(|e| paf_str.ends_with(e));
+
+        info!("Building chain index for {}...", paf_str);
+        let mut chains = HashMap::new();
+
+        if is_compressed {
+            // Handle compressed files
+            Self::build_index_for_compressed_file(paf_path, &mut chains)?;
+        } else {
+            // Handle uncompressed files
+            Self::build_index_for_uncompressed_file(paf_path, &mut chains)?;
+        }
+
+        // Sort entries by chain position
+        for entries in chains.values_mut() {
+            entries.sort_by_key(|e| e.chain_pos);
+        }
+
+        info!("Found {} chains", chains.len());
+        Ok(Self {
+            chains,
+            paf_file: paf_str,
+            is_compressed,
+        })
+    }
+
+    /// Build index for a compressed PAF file
+    fn build_index_for_compressed_file(
+        paf_path: &Path,
+        chains: &mut HashMap<u64, Vec<ChainEntryInfo>>,
+    ) -> Result<(), Box<dyn Error>> {
+        let file = File::open(paf_path)?;
+        let reader = bgzf::Reader::new(file);
+        let mut buf_reader = BufReader::new(reader);
+
+        let mut offset = 0;
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            let bytes_read = buf_reader.read_line(&mut line)?;
+            if bytes_read == 0 {
+                break;
+            }
+
+            if let Ok(entry) = PafEntry::parse_from_line(&line) {
+                let chain_entry = ChainEntryInfo {
+                    offset,
+                    length: bytes_read,
+                    chain_pos: entry.chain_pos,
+                };
+                chains
+                    .entry(entry.chain_id)
+                    .or_insert_with(Vec::new)
+                    .push(chain_entry);
+            }
+
+            offset += bytes_read as u64;
+        }
+
+        Ok(())
+    }
+
+    /// Build index for an uncompressed PAF file
+    fn build_index_for_uncompressed_file(
+        paf_path: &Path,
+        chains: &mut HashMap<u64, Vec<ChainEntryInfo>>,
+    ) -> Result<(), Box<dyn Error>> {
+        let file = File::open(paf_path)?;
+        let reader = BufReader::new(file);
+
+        let mut offset = 0;
+
+        for line_result in reader.lines() {
+            let line = line_result?;
+            let line_len = line.len() + 1; // +1 for newline
+
+            if let Ok(entry) = PafEntry::parse_from_line(&line) {
+                let chain_entry = ChainEntryInfo {
+                    offset,
+                    length: line_len,
+                    chain_pos: entry.chain_pos,
+                };
+                chains
+                    .entry(entry.chain_id)
+                    .or_insert_with(Vec::new)
+                    .push(chain_entry);
+            }
+
+            offset += line_len as u64;
+        }
+
+        Ok(())
+    }
+
+    /// Load all entries for a specific chain
+    pub fn load_chain(&self, chain_id: u64) -> Result<Vec<PafEntry>, Box<dyn Error>> {
+        let entries = match self.chains.get(&chain_id) {
+            Some(entries) => entries,
+            None => return Ok(Vec::new()),
+        };
+
+        debug!("Loading chain {} with {} entries", chain_id, entries.len());
+
+        if self.is_compressed {
+            self.load_chain_compressed(chain_id, entries)
+        } else {
+            self.load_chain_uncompressed(chain_id, entries)
+        }
+    }
+
+    /// Load chain entries from a compressed file
+    fn load_chain_compressed(
+        &self,
+        chain_id: u64,
+        entries: &[ChainEntryInfo],
+    ) -> Result<Vec<PafEntry>, Box<dyn Error>> {
+        let gzi_path = format!("{}.gzi", self.paf_file);
+        let gzi_index = bgzf::gzi::read(gzi_path)?;
+
+        let file = File::open(&self.paf_file)?;
+        let mut reader = bgzf::Reader::new(file);
+        let mut paf_entries = Vec::with_capacity(entries.len());
+
+        for entry_info in entries {
+            let mut buffer = vec![0; entry_info.length];
+
+            reader.seek_by_uncompressed_position(&gzi_index, entry_info.offset)?;
+            reader.read_exact(&mut buffer)?;
+
+            let line = std::str::from_utf8(&buffer[..buffer.len() - 1])?; // Remove newline
+            if let Ok(paf_entry) = PafEntry::parse_from_line(line) {
+                // Verify chain_id matches
+                if paf_entry.chain_id == chain_id {
+                    paf_entries.push(paf_entry);
+                } else {
+                    return Err(format!(
+                        "Chain ID mismatch: expected {}, got {}",
+                        chain_id, paf_entry.chain_id
+                    )
+                    .into());
+                }
+            }
+        }
+
+        Ok(paf_entries)
+    }
+
+    /// Load chain entries from an uncompressed file
+    fn load_chain_uncompressed(
+        &self,
+        chain_id: u64,
+        entries: &[ChainEntryInfo],
+    ) -> Result<Vec<PafEntry>, Box<dyn Error>> {
+        let file = File::open(&self.paf_file)?;
+        let mut reader = BufReader::new(file);
+        let mut paf_entries = Vec::with_capacity(entries.len());
+
+        for entry_info in entries {
+            let mut buffer = vec![0; entry_info.length];
+
+            reader.seek(SeekFrom::Start(entry_info.offset))?;
+            reader.read_exact(&mut buffer)?;
+
+            let line = std::str::from_utf8(&buffer[..buffer.len() - 1])?; // Remove newline
+            if let Ok(paf_entry) = PafEntry::parse_from_line(line) {
+                // Verify chain_id matches
+                if paf_entry.chain_id == chain_id {
+                    paf_entries.push(paf_entry);
+                } else {
+                    return Err(format!(
+                        "Chain ID mismatch: expected {}, got {}",
+                        chain_id, paf_entry.chain_id
+                    )
+                    .into());
+                }
+            }
+        }
+
+        Ok(paf_entries)
+    }
+
+    /// Save the index to a file
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), Box<dyn Error>> {
+        let file = File::create(path)?;
+        let writer = io::BufWriter::new(file);
+        bincode::serialize_into(writer, self)?;
+        Ok(())
+    }
+
+    /// Load an index from a file
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn Error>> {
+        let file = File::open(path)?;
+        let reader = io::BufReader::new(file);
+        let index: ChainIndex = bincode::deserialize_from(reader)?;
+        Ok(index)
+    }
+
+    /// Get a list of all chain IDs in the index
+    pub fn get_chain_ids(&self) -> Vec<u64> {
+        self.chains.keys().cloned().collect()
+    }
+
+    /// Get the number of chains in the index
+    pub fn num_chains(&self) -> usize {
+        self.chains.len()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod chain_index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,40 +1,44 @@
-use std::collections::{HashSet, HashMap};
+use clap::Parser;
+use lib_wfa2::affine_wavefront::{AffineWavefronts, AlignmentStatus};
+use libc;
+use log::{debug, info, warn};
+use rust_htslib::faidx::Reader as FastaReader;
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
 use std::fs::File;
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
-use std::error::Error;
-use clap::Parser;
-use log::{info, warn, debug};
-use lib_wfa2::affine_wavefront::{AffineWavefronts, AlignmentStatus};
-use rust_htslib::faidx::Reader as FastaReader;
-use libc;
 use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
 
-use pafchainer::chain_index::{PafEntry, ChainIndex};
+use pafchainer::chain_index::{ChainIndex, PafEntry};
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about = "A tool for merging WFMASH's alignment chains using the WFA algorithm.")]
+#[clap(
+    author,
+    version,
+    about = "A tool for merging WFMASH's alignment chains using the WFA algorithm."
+)]
 struct Args {
     /// Input PAF file
     #[clap(short, long)]
     paf: PathBuf,
-    
+
     /// Query FASTA file
     #[clap(short, long)]
     query: PathBuf,
-    
+
     /// Target FASTA file
     #[clap(short, long)]
     target: PathBuf,
-    
+
     /// Size of boundary erosion in base pairs
     #[clap(short, long, default_value = "100")]
     erosion_size: usize,
-    
+
     /// Output PAF file
     #[clap(short, long)]
     output: Option<PathBuf>,
-    
+
     /// Output in SAM format instead of PAF
     #[clap(long)]
     sam: bool,
@@ -64,32 +68,44 @@ impl SequenceDB {
             reader: FastaReader::from_path(path)?,
         })
     }
-    
+
     // Get a subsequence from the database
-    fn get_subsequence(&self, name: &str, start: u64, end: u64, reverse_complement: bool) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn get_subsequence(
+        &self,
+        name: &str,
+        start: u64,
+        end: u64,
+        reverse_complement: bool,
+    ) -> Result<Vec<u8>, Box<dyn Error>> {
         let start_usize = start as usize;
         let end_usize = std::cmp::min(end as usize, std::usize::MAX);
-        
+
         // Fetch sequence and properly handle memory
         let seq = match self.reader.fetch_seq(name, start_usize, end_usize - 1) {
             Ok(seq) => {
                 let mut seq_vec = seq.to_vec();
-                unsafe {libc::free(seq.as_ptr() as *mut std::ffi::c_void)}; // Free up memory to avoid memory leak (bug https://github.com/rust-bio/rust-htslib/issues/401#issuecomment-1704290171)
-                seq_vec.iter_mut().for_each(|byte| *byte = byte.to_ascii_uppercase());
+                unsafe { libc::free(seq.as_ptr() as *mut std::ffi::c_void) }; // Free up memory to avoid memory leak (bug https://github.com/rust-bio/rust-htslib/issues/401#issuecomment-1704290171)
                 seq_vec
-            },
+                    .iter_mut()
+                    .for_each(|byte| *byte = byte.to_ascii_uppercase());
+                seq_vec
+            }
             Err(e) => return Err(format!("Failed to fetch sequence for {}: {}", name, e).into()),
         };
-        
+
         if reverse_complement {
             // Reverse complement the sequence
-            Ok(seq.iter().rev().map(|&b| match b {
-                b'A' => b'T',
-                b'T' => b'A',
-                b'G' => b'C',
-                b'C' => b'G',
-                x => x,
-            }).collect())
+            Ok(seq
+                .iter()
+                .rev()
+                .map(|&b| match b {
+                    b'A' => b'T',
+                    b'T' => b'A',
+                    b'G' => b'C',
+                    b'C' => b'G',
+                    x => x,
+                })
+                .collect())
         } else {
             Ok(seq)
         }
@@ -100,7 +116,7 @@ impl SequenceDB {
 fn cigar_to_ops(cigar: &str) -> Result<Vec<CigarOp>, Box<dyn Error>> {
     let mut ops = Vec::new();
     let mut count = 0;
-    
+
     for c in cigar.chars() {
         if c.is_digit(10) {
             count = count * 10 + c.to_digit(10).unwrap() as usize;
@@ -109,11 +125,11 @@ fn cigar_to_ops(cigar: &str) -> Result<Vec<CigarOp>, Box<dyn Error>> {
             count = 0;
         }
     }
-    
+
     if count > 0 {
         return Err("CIGAR string ended with a number".into());
     }
-    
+
     Ok(ops)
 }
 
@@ -133,10 +149,10 @@ fn cigar_u8_to_ops(cigar: &[u8]) -> Vec<(usize, char)> {
         } else {
             // Convert the operation
             let cigar_op = match last_op {
-                b'M' => '=',  // Match
-                b'X' => 'X',  // Mismatch
-                b'D' => 'D',  // Deletion
-                b'I' => 'I',  // Insertion
+                b'M' => '=', // Match
+                b'X' => 'X', // Mismatch
+                b'D' => 'D', // Deletion
+                b'I' => 'I', // Insertion
                 _ => panic!("Unknown CIGAR operation: {}", last_op),
             };
             ops.push((count, cigar_op));
@@ -160,45 +176,53 @@ fn cigar_u8_to_ops(cigar: &[u8]) -> Vec<(usize, char)> {
 
 // Convert CIGAR operations to string
 fn ops_to_cigar(ops: &[CigarOp]) -> String {
-    ops.iter().map(|&CigarOp(op, count)| format!("{}{}", count, op)).collect()
+    ops.iter()
+        .map(|&CigarOp(op, count)| format!("{}{}", count, op))
+        .collect()
 }
 
 // Erode CIGAR from the end with separate query and target erosion limits
-fn erode_cigar_end(cigar: &str, query_bp_limit: usize, target_bp_limit: usize) -> Result<(String, usize, usize), Box<dyn Error>> {
+fn erode_cigar_end(
+    cigar: &str,
+    query_bp_limit: usize,
+    target_bp_limit: usize,
+) -> Result<(String, usize, usize), Box<dyn Error>> {
     let ops = cigar_to_ops(cigar)?;
     let mut new_ops = Vec::new();
     let mut remaining_query_bp = query_bp_limit;
     let mut remaining_target_bp = target_bp_limit;
     let mut query_bases_removed = 0;
     let mut target_bases_removed = 0;
-    
-    debug!("\tEroding from end of CIGAR - Query limit: {} bp, Target limit: {} bp", 
-          query_bp_limit, target_bp_limit);
-    
+
+    debug!(
+        "\tEroding from end of CIGAR - Query limit: {} bp, Target limit: {} bp",
+        query_bp_limit, target_bp_limit
+    );
+
     // Copy operations from beginning until we need to erode
     let mut i = 0;
     while i < ops.len() && (remaining_query_bp > 0 || remaining_target_bp > 0) {
         // Process operations from the end
         let idx = ops.len() - 1 - i;
         let CigarOp(op, count) = ops[idx];
-        
+
         // debug!("\t\terode_cigar_end - Processing operation: {}{}", count, op);
-        
+
         match op {
             '=' | 'X' | 'M' => {
                 // Advances both sequences
                 if remaining_query_bp > 0 || remaining_target_bp > 0 {
                     let query_erosion = std::cmp::min(count, remaining_query_bp);
                     let target_erosion = std::cmp::min(count, remaining_target_bp);
-                    
+
                     // Determine actual erosion
                     let actual_erosion = std::cmp::max(query_erosion, target_erosion);
-                    
+
                     if actual_erosion < count {
                         // Partial erosion
                         new_ops.insert(0, CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     query_bases_removed += actual_erosion;
                     target_bases_removed += actual_erosion;
                     remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
@@ -207,19 +231,19 @@ fn erode_cigar_end(cigar: &str, query_bp_limit: usize, target_bp_limit: usize) -
                     // No more erosion needed
                     new_ops.insert(0, CigarOp(op, count));
                 }
-            },
+            }
             'I' => {
                 // Insertion only advances query
                 if remaining_query_bp > 0 {
                     let actual_erosion = count;
-                    
+
                     query_bases_removed += actual_erosion;
                     remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
                 } else {
                     // No more query erosion needed
                     new_ops.insert(0, CigarOp(op, count));
                 }
-            },
+            }
             'D' => {
                 // Deletion only advances target
                 if remaining_target_bp > 0 {
@@ -231,51 +255,61 @@ fn erode_cigar_end(cigar: &str, query_bp_limit: usize, target_bp_limit: usize) -
                     // No more target erosion needed
                     new_ops.insert(0, CigarOp(op, count));
                 }
-            },
+            }
             _ => new_ops.insert(0, CigarOp(op, count)), // Keep other operations
         }
-        
+
         i += 1;
-        
-        // debug!("\t\tProgress - Eroded from query: {}/{}, target: {}/{}", 
-        //       query_bases_removed, query_bp_limit, 
+
+        // debug!("\t\tProgress - Eroded from query: {}/{}, target: {}/{}",
+        //       query_bases_removed, query_bp_limit,
         //       target_bases_removed, target_bp_limit);
     }
-    
+
     // Add remaining operations
     for j in 0..(ops.len() - i) {
         new_ops.insert(j, ops[j]);
     }
-    
-    Ok((ops_to_cigar(&new_ops), query_bases_removed, target_bases_removed))
+
+    Ok((
+        ops_to_cigar(&new_ops),
+        query_bases_removed,
+        target_bases_removed,
+    ))
 }
 
 // Erode CIGAR from the start with separate query and target erosion limits
-fn erode_cigar_start(cigar: &str, query_bp_limit: usize, target_bp_limit: usize) -> Result<(String, usize, usize), Box<dyn Error>> {
+fn erode_cigar_start(
+    cigar: &str,
+    query_bp_limit: usize,
+    target_bp_limit: usize,
+) -> Result<(String, usize, usize), Box<dyn Error>> {
     let ops = cigar_to_ops(cigar)?;
     let mut new_ops = Vec::new();
     let mut remaining_query_bp = query_bp_limit;
     let mut remaining_target_bp = target_bp_limit;
     let mut query_bases_removed = 0;
     let mut target_bases_removed = 0;
-    
-    debug!("\tEroding from start of CIGAR - Query limit: {} bp, Target limit: {} bp", 
-          query_bp_limit, target_bp_limit);
-    
+
+    debug!(
+        "\tEroding from start of CIGAR - Query limit: {} bp, Target limit: {} bp",
+        query_bp_limit, target_bp_limit
+    );
+
     // Skip or partially include first operations until eroded enough
     let mut i = 0;
     while i < ops.len() && (remaining_query_bp > 0 || remaining_target_bp > 0) {
         let CigarOp(op, count) = ops[i];
-        
+
         // debug!("\t\terode_cigar_start - Processing operation: {}{}", count, op);
-        
+
         match op {
             '=' | 'X' | 'M' => {
                 // Advances both sequences
                 if remaining_query_bp > 0 || remaining_target_bp > 0 {
                     let query_erosion = std::cmp::min(count, remaining_query_bp);
                     let target_erosion = std::cmp::min(count, remaining_target_bp);
-                    
+
                     // Determine actual erosion
                     let actual_erosion = std::cmp::max(query_erosion, target_erosion);
 
@@ -283,7 +317,7 @@ fn erode_cigar_start(cigar: &str, query_bp_limit: usize, target_bp_limit: usize)
                         // Partial erosion
                         new_ops.push(CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     query_bases_removed += actual_erosion;
                     target_bases_removed += actual_erosion;
                     remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
@@ -292,64 +326,72 @@ fn erode_cigar_start(cigar: &str, query_bp_limit: usize, target_bp_limit: usize)
                     // No more erosion needed
                     new_ops.push(CigarOp(op, count));
                 }
-            },
+            }
             'I' => {
                 // Insertion only advances query
                 if remaining_query_bp > 0 {
                     let actual_erosion = std::cmp::min(count, remaining_query_bp);
-                    
+
                     if actual_erosion < count {
                         // Partial erosion
                         new_ops.push(CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     query_bases_removed += actual_erosion;
                     remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
                 } else {
                     // No more query erosion needed
                     new_ops.push(CigarOp(op, count));
                 }
-            },
+            }
             'D' => {
                 // Deletion only advances target
                 if remaining_target_bp > 0 {
                     let actual_erosion = std::cmp::min(count, remaining_target_bp);
-                    
+
                     if actual_erosion < count {
                         // Partial erosion
                         new_ops.push(CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     target_bases_removed += actual_erosion;
                     remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
                 } else {
                     // No more target erosion needed
                     new_ops.push(CigarOp(op, count));
                 }
-            },
+            }
             _ => new_ops.push(CigarOp(op, count)), // Keep other operations
         }
-        
+
         i += 1;
-        
-        // debug!("\t\tProgress - Eroded from query: {}/{}, target: {}/{}", 
-        //       query_bases_removed, query_bp_limit, 
+
+        // debug!("\t\tProgress - Eroded from query: {}/{}, target: {}/{}",
+        //       query_bases_removed, query_bp_limit,
         //       target_bases_removed, target_bp_limit);
     }
-    
+
     // Add all remaining operations
     while i < ops.len() {
         new_ops.push(ops[i]);
         i += 1;
     }
-    
-    Ok((ops_to_cigar(&new_ops), query_bases_removed, target_bases_removed))
+
+    Ok((
+        ops_to_cigar(&new_ops),
+        query_bases_removed,
+        target_bases_removed,
+    ))
 }
 
 // Align two sequences using WFA
 fn align_sequences_wfa(query: &[u8], target: &[u8]) -> Result<String, Box<dyn Error>> {
-    debug!("Performing WFA alignment between sequences of lengths {} and {}", query.len(), target.len());
-    
+    debug!(
+        "Performing WFA alignment between sequences of lengths {} and {}",
+        query.len(),
+        target.len()
+    );
+
     // Initialize WFA aligner with gap-affine penalties
     let match_score = 0;
     let mismatch = 3;
@@ -357,48 +399,54 @@ fn align_sequences_wfa(query: &[u8], target: &[u8]) -> Result<String, Box<dyn Er
     let gap_ext1 = 2;
     let gap_open2 = 24;
     let gap_ext2 = 1;
-    
+
     let aligner = AffineWavefronts::with_penalties_affine2p(
-        match_score, mismatch, gap_open1, gap_ext1, gap_open2, gap_ext2
+        match_score,
+        mismatch,
+        gap_open1,
+        gap_ext1,
+        gap_open2,
+        gap_ext2,
     );
-    
+
     // Perform alignment (note that WFA expects target, query order)
     let status = aligner.align(target, query);
-    
+
     // Check alignment status (can't use != since AlignmentStatus doesn't implement PartialEq)
     match status {
         AlignmentStatus::Completed => {
             debug!("WFA alignment completed successfully");
-        },
+        }
         s => {
             warn!("Alignment failed with status: {:?}", s);
             return Err(format!("Alignment failed with status: {:?}", s).into());
         }
     }
-    
+
     // Convert CIGAR to string
     let cigar_ops = cigar_u8_to_ops(aligner.cigar());
-    let cigar = cigar_ops.iter()
+    let cigar = cigar_ops
+        .iter()
         .map(|(count, op)| format!("{}{}", count, op))
         .collect::<String>();
-    
+
     Ok(cigar)
 }
 
 // Merge multiple CIGAR strings
 fn merge_cigars(cigars: &[&str]) -> Result<String, Box<dyn Error>> {
     let mut all_ops = Vec::new();
-    
+
     // Collect all operations
     for &cigar in cigars {
         let ops = cigar_to_ops(cigar)?;
         all_ops.extend_from_slice(&ops);
     }
-    
+
     // Optimize by combining adjacent operations of the same type
     let mut optimized_ops = Vec::new();
     let mut current_op = None;
-    
+
     for op in all_ops {
         if let Some(CigarOp(prev_op, prev_count)) = current_op {
             if prev_op == op.0 {
@@ -411,31 +459,44 @@ fn merge_cigars(cigars: &[&str]) -> Result<String, Box<dyn Error>> {
             current_op = Some(op);
         }
     }
-    
+
     if let Some(op) = current_op {
         optimized_ops.push(op);
     }
-    
+
     Ok(ops_to_cigar(&optimized_ops))
 }
 
 // Calculate CIGAR statistics
-fn calculate_cigar_stats(cigar: &str) -> Result<(u64, u64, u64, u64, u64, u64, u64), Box<dyn Error>> {
+fn calculate_cigar_stats(
+    cigar: &str,
+) -> Result<(u64, u64, u64, u64, u64, u64, u64), Box<dyn Error>> {
     let ops = cigar_to_ops(cigar)?;
-    let (matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len) = 
-        ops.iter().fold((0, 0, 0, 0, 0, 0, 0), |(m, mm, i, i_bp, d, d_bp, bl), &CigarOp(op, len)| {
-            let len = len as u64;
-            match op {
-                'M' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
-                '=' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
-                'X' => (m, mm + len, i, i_bp, d, d_bp, bl + len),
-                'I' => (m, mm, i + 1, i_bp + len, d, d_bp, bl + len),
-                'D' => (m, mm, i, i_bp, d + 1, d_bp + len, bl + len),
-                _ => (m, mm, i, i_bp, d, d_bp, bl),
-            }
-        });
-    
-    Ok((matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len))
+    let (matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len) =
+        ops.iter().fold(
+            (0, 0, 0, 0, 0, 0, 0),
+            |(m, mm, i, i_bp, d, d_bp, bl), &CigarOp(op, len)| {
+                let len = len as u64;
+                match op {
+                    'M' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
+                    '=' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
+                    'X' => (m, mm + len, i, i_bp, d, d_bp, bl + len),
+                    'I' => (m, mm, i + 1, i_bp + len, d, d_bp, bl + len),
+                    'D' => (m, mm, i, i_bp, d + 1, d_bp + len, bl + len),
+                    _ => (m, mm, i, i_bp, d, d_bp, bl),
+                }
+            },
+        );
+
+    Ok((
+        matches,
+        mismatches,
+        insertions,
+        inserted_bp,
+        deletions,
+        deleted_bp,
+        block_len,
+    ))
 }
 
 // Write PAF entries to a writer
@@ -443,44 +504,44 @@ fn write_paf_content<W: Write>(writer: &mut W, entries: &[PafEntry]) -> Result<(
     for entry in entries {
         writeln!(writer, "{}", entry.to_string())?;
     }
-    
+
     Ok(())
 }
 
 // Generate SAM header
 fn generate_sam_header(entries: &[PafEntry]) -> String {
     let mut header = String::new();
-    
+
     // Add SAM version header
     header.push_str("@HD\tVN:1.6\tSO:unsorted\n");
-    
+
     // Add reference sequence information
     let mut target_seen = HashSet::new();
     for entry in entries {
         if !target_seen.contains(&entry.target_name) {
             header.push_str(&format!(
-                "@SQ\tSN:{}\tLN:{}\n", 
+                "@SQ\tSN:{}\tLN:{}\n",
                 entry.target_name, entry.target_length
             ));
             target_seen.insert(entry.target_name.clone());
         }
     }
-    
+
     // Add program information
     header.push_str("@PG\tID:pafchainer\tPN:pafchainer\tVN:0.1.0\n");
-    
+
     header
 }
 
 // Convert PafEntry to SAM format
 fn paf_entry_to_sam(
-    entry: &PafEntry, 
+    entry: &PafEntry,
     query_db: &SequenceDB,
-    reference_id_map: &HashMap<String, usize>
+    reference_id_map: &HashMap<String, usize>,
 ) -> Result<String, Box<dyn Error>> {
     // Calculate flag
     let flag = if entry.strand == '-' { 16 } else { 0 };
-    
+
     // Get reference ID
     let ref_id = match reference_id_map.get(&entry.target_name) {
         Some(_) => entry.target_name.clone(),
@@ -488,43 +549,44 @@ fn paf_entry_to_sam(
     };
 
     let sam_cigar = &entry.cigar;
-    
+
     // Fetch sequence
     let sequence = query_db.get_subsequence(
         &entry.query_name,
         entry.query_start,
         entry.query_end,
-        entry.strand == '-'
+        entry.strand == '-',
     )?;
-    
+
     // Convert sequence to string
-    let seq_str = std::str::from_utf8(&sequence)
-        .map_err(|e| format!("Invalid UTF-8 sequence: {}", e))?;
-    
+    let seq_str =
+        std::str::from_utf8(&sequence).map_err(|e| format!("Invalid UTF-8 sequence: {}", e))?;
+
     // MAPQ (mapping quality)
     let mapq = entry.mapping_quality.min(255);
-    
+
     // Calculate TLEN (observed template length)
     let tlen = entry.target_end as i64 - entry.target_start as i64;
-    
+
     // Build optional fields
     let mut optional_fields = Vec::new();
-    
+
     // Add chain info as optional field
-    optional_fields.push(format!("ch:Z:{}.{}.{}", 
-        entry.chain_id, entry.chain_length, entry.chain_pos));
-    
+    optional_fields.push(format!(
+        "ch:Z:{}.{}.{}",
+        entry.chain_id, entry.chain_length, entry.chain_pos
+    ));
+
     // Add NM tag (edit distance)
-    let (matches, mismatches, _, ins_bp, _, del_bp, _) = 
-        calculate_cigar_stats(&entry.cigar)?;
+    let (matches, mismatches, _, ins_bp, _, del_bp, _) = calculate_cigar_stats(&entry.cigar)?;
     let edit_distance = mismatches + ins_bp + del_bp;
     optional_fields.push(format!("NM:i:{}", edit_distance));
-    
+
     // Add AS tag (alignment score)
     // Simple scoring: +1 for match, -1 for mismatch/indel
     let alignment_score = matches as i64 - edit_distance as i64;
     optional_fields.push(format!("AS:i:{}", alignment_score));
-    
+
     // Format SAM line
     // QNAME FLAG RNAME POS MAPQ CIGAR RNEXT PNEXT TLEN SEQ QUAL [TAGS]
     let sam_line = format!(
@@ -539,16 +601,20 @@ fn paf_entry_to_sam(
         seq_str,
         optional_fields.join("\t")
     );
-    
+
     Ok(sam_line)
 }
 
 // Write SAM content to a writer
-fn write_sam_content<W: Write>(writer: &mut W, entries: &[PafEntry], query_db: &SequenceDB) -> Result<(), Box<dyn Error>> {
+fn write_sam_content<W: Write>(
+    writer: &mut W,
+    entries: &[PafEntry],
+    query_db: &SequenceDB,
+) -> Result<(), Box<dyn Error>> {
     // Generate and write header
     let header = generate_sam_header(entries);
     write!(writer, "{}", header)?;
-    
+
     // Create reference ID map for quick lookups
     let mut reference_id_map = HashMap::new();
     let mut ref_id = 0;
@@ -558,7 +624,7 @@ fn write_sam_content<W: Write>(writer: &mut W, entries: &[PafEntry], query_db: &
             ref_id += 1;
         }
     }
-    
+
     // Write alignment lines
     for entry in entries {
         match paf_entry_to_sam(entry, query_db, &reference_id_map) {
@@ -566,7 +632,7 @@ fn write_sam_content<W: Write>(writer: &mut W, entries: &[PafEntry], query_db: &
             Err(e) => warn!("Failed to convert entry to SAM: {}", e),
         }
     }
-    
+
     Ok(())
 }
 
@@ -589,12 +655,12 @@ fn update_tags(tags: &[(String, String)], cigar: &str, chain_id: u64) -> Vec<(St
 fn create_merged_entry(
     base_entry: &PafEntry,
     next_entry: &PafEntry,
-    merged_cigar: &str
+    merged_cigar: &str,
 ) -> PafEntry {
     // Calculate statistics from merged CIGAR
-    let (matches, _, _, _, _, _, block_len) = calculate_cigar_stats(merged_cigar)
-        .expect("Failed to calculate CIGAR stats");
-    
+    let (matches, _, _, _, _, _, block_len) =
+        calculate_cigar_stats(merged_cigar).expect("Failed to calculate CIGAR stats");
+
     // Adjust target range based on strand
     let (adjusted_target_start, adjusted_target_end) = if base_entry.strand == '-' {
         (next_entry.target_start, base_entry.target_end)
@@ -626,36 +692,48 @@ fn create_merged_entry(
 
 // Process a chain
 fn process_chain(
-    chain: &[PafEntry], 
-    query_db: &SequenceDB, 
+    chain: &[PafEntry],
+    query_db: &SequenceDB,
     target_db: &SequenceDB,
-    erosion_size: usize
+    erosion_size: usize,
 ) -> Result<Vec<PafEntry>, Box<dyn Error>> {
     // Handle simple cases
     if chain.len() <= 1 {
         debug!("Chain has only one entry, returning unchanged");
         return Ok(chain.to_vec());
     }
-        
+
     // Sort chain by position
     let mut sorted_chain = chain.to_vec();
     sorted_chain.sort_by_key(|entry| entry.chain_pos);
-    
+
     // Start with the first entry as our base for merging
     let mut merged_entry = sorted_chain[0].clone();
-    
+
     // Process each pair of adjacent entries
-    for i in 0..(sorted_chain.len() - 1) {      
+    for i in 0..(sorted_chain.len() - 1) {
         debug!("\tProcessing entries {} and {}", i, i + 1);
 
         // Get the current base entry and the next entry to merge
         let current = &merged_entry;
-        let next = &sorted_chain[i+1];
+        let next = &sorted_chain[i + 1];
 
-        debug!("\tMerged query {}-{}; {}; target {}-{}", merged_entry.query_start, merged_entry.query_end, merged_entry.strand, merged_entry.target_start, merged_entry.target_end);
-        debug!("\tNext   query {}-{}; {}; target {}-{}", next.query_start, next.query_end, next.strand, next.target_start, next.target_end);
-        //debug!("\tCIGAR: {}", merged_entry.cigar);
-        debug!("\tChain: {}.{}.{}", merged_entry.chain_id, merged_entry.chain_length, next.chain_pos);
+        debug!(
+            "\tMerged query {}-{}; {}; target {}-{}",
+            merged_entry.query_start,
+            merged_entry.query_end,
+            merged_entry.strand,
+            merged_entry.target_start,
+            merged_entry.target_end
+        );
+        debug!(
+            "\tNext   query {}-{}; {}; target {}-{}",
+            next.query_start, next.query_end, next.strand, next.target_start, next.target_end
+        );
+        debug!(
+            "\tChain: {}.{}.{}",
+            merged_entry.chain_id, merged_entry.chain_length, next.chain_pos
+        );
 
         // Check for query overlap
         let query_overlap = if next.query_start < current.query_end {
@@ -686,58 +764,83 @@ fn process_chain(
         let min_query_erosion_size = if query_overlap > 0 {
             // Use at least the overlap size for erosion if an overlap exists
             let min_size = std::cmp::max(erosion_size, query_overlap);
-            debug!("\tUsing min. query erosion size of {} bp due to query overlap of {} bp", 
-                  min_size, query_overlap);
+            debug!(
+                "\tUsing min. query erosion size of {} bp due to query overlap of {} bp",
+                min_size, query_overlap
+            );
             min_size
         } else {
             // No overlap, use the specified erosion size
-            debug!("\tUsing specified erosion size of {} bp due to no query overlap detected", erosion_size);
+            debug!(
+                "\tUsing specified erosion size of {} bp due to no query overlap detected",
+                erosion_size
+            );
             erosion_size
         };
-        
+
         let min_target_erosion_size = if target_overlap > 0 {
             // Use at least the overlap size for erosion if an overlap exists
             let min_size = std::cmp::max(erosion_size, target_overlap);
-            debug!("\tUsing min. target erosion size of {} bp due to target overlap of {} bp", 
-                  min_size, target_overlap);
+            debug!(
+                "\tUsing min. target erosion size of {} bp due to target overlap of {} bp",
+                min_size, target_overlap
+            );
             min_size
         } else {
             // No overlap, use the specified erosion size
-            debug!("\tUsing specified erosion size of {} bp due to no target overlap detected", erosion_size);
+            debug!(
+                "\tUsing specified erosion size of {} bp due to no target overlap detected",
+                erosion_size
+            );
             erosion_size
         };
-        
-        // Erode CIGARs at boundaries with the effective erosion sizes
-        let (eroded_current_cigar, current_query_removed, current_target_removed) = 
-        if min_query_erosion_size > 0 || min_target_erosion_size > 0 {
-            if current.strand == '-' {
-                // For reverse strand, erode the start of the current entry
-                erode_cigar_start(&current.cigar, min_query_erosion_size, min_target_erosion_size)?
-            } else {
-                // For forward strand, erode the end of the current entry
-                erode_cigar_end(&current.cigar, min_query_erosion_size, min_target_erosion_size)?
-            }
-        } else {
-            (current.cigar.clone(), 0, 0)
-        };
-        debug!("\tEroded CIGARs - Current: query: {}, target: {}", current_query_removed, current_target_removed);
 
-        let (eroded_next_cigar, next_query_removed, next_target_removed) = 
+        // Erode CIGARs at boundaries with the effective erosion sizes
+        let (eroded_current_cigar, current_query_removed, current_target_removed) =
+            if min_query_erosion_size > 0 || min_target_erosion_size > 0 {
+                if current.strand == '-' {
+                    // For reverse strand, erode the start of the current entry
+                    erode_cigar_start(
+                        &current.cigar,
+                        min_query_erosion_size,
+                        min_target_erosion_size,
+                    )?
+                } else {
+                    // For forward strand, erode the end of the current entry
+                    erode_cigar_end(
+                        &current.cigar,
+                        min_query_erosion_size,
+                        min_target_erosion_size,
+                    )?
+                }
+            } else {
+                (current.cigar.clone(), 0, 0)
+            };
+        debug!(
+            "\tEroded CIGARs - Current: query: {}, target: {}",
+            current_query_removed, current_target_removed
+        );
+
         // Only erode the start of next entry if there's no overlap
         // (otherwise we've already handled the overlap by eroding the current entry)
-        if (min_query_erosion_size > 0 && query_overlap == 0) || 
-        (min_target_erosion_size > 0 && target_overlap == 0) {
-            if current.strand == '-' {
-                // For reverse strand, erode the end of the next entry
-                erode_cigar_end(&next.cigar, min_query_erosion_size, min_target_erosion_size)?
+        let (eroded_next_cigar, next_query_removed, next_target_removed) =
+            if (min_query_erosion_size > 0 && query_overlap == 0)
+                || (min_target_erosion_size > 0 && target_overlap == 0)
+            {
+                if current.strand == '-' {
+                    // For reverse strand, erode the end of the next entry
+                    erode_cigar_end(&next.cigar, min_query_erosion_size, min_target_erosion_size)?
+                } else {
+                    // For forward strand, erode the start of the next entry
+                    erode_cigar_start(&next.cigar, min_query_erosion_size, min_target_erosion_size)?
+                }
             } else {
-                // For forward strand, erode the start of the next entry
-                erode_cigar_start(&next.cigar, min_query_erosion_size, min_target_erosion_size)?
-            }
-        } else {
-            (next.cigar.clone(), 0, 0)
-        };
-        debug!("\tEroded CIGARs - Next: query: {}, target: {}", next_query_removed, next_target_removed);
+                (next.cigar.clone(), 0, 0)
+            };
+        debug!(
+            "\tEroded CIGARs - Next: query: {}, target: {}",
+            next_query_removed, next_target_removed
+        );
 
         // Calculate gap coordinates accounting for erosion
         let query_gap_start = current.query_end - current_query_removed as u64;
@@ -745,18 +848,30 @@ fn process_chain(
         // Check the strand to determine the target gap coordinates
         let (target_gap_start, target_gap_end) = if current.strand == '-' {
             // For reverse strand, subtract the erosion from the start of the next entry
-            (next.target_end - next_target_removed as u64, current.target_start + current_target_removed as u64)
+            (
+                next.target_end - next_target_removed as u64,
+                current.target_start + current_target_removed as u64,
+            )
         } else {
             // For forward strand, add the erosion to the start of the next entry
-            (current.target_end - current_target_removed as u64, next.target_start + next_target_removed as u64)
+            (
+                current.target_end - current_target_removed as u64,
+                next.target_start + next_target_removed as u64,
+            )
         };
-        debug!("\tGap coordinates - Query: {}-{}, Target: {}-{}", query_gap_start, query_gap_end, target_gap_start, target_gap_end);
+        debug!(
+            "\tGap coordinates - Query: {}-{}, Target: {}-{}",
+            query_gap_start, query_gap_end, target_gap_start, target_gap_end
+        );
 
         // Calculate gap sizes
         let query_gap = query_gap_end - query_gap_start;
         let target_gap = target_gap_end - target_gap_start;
-        debug!("\tAfter erosion - Query gap: {}, Target gap: {}", query_gap, target_gap);
-        
+        debug!(
+            "\tAfter erosion - Query gap: {}, Target gap: {}",
+            query_gap, target_gap
+        );
+
         // Fetch sequences for alignment
         let gap_cigar = if query_gap == 0 && target_gap == 0 {
             // No gaps after erosion, nothing to align
@@ -773,57 +888,61 @@ fn process_chain(
                 &current.query_name,
                 query_gap_start,
                 query_gap_end,
-                current.strand == '-'
+                current.strand == '-',
             )?;
-            
+
             let gap_target_seq = target_db.get_subsequence(
                 &current.target_name,
                 target_gap_start,
                 target_gap_end,
-                false
+                false,
             )?;
-            
+
             // Align the gap sequences
             align_sequences_wfa(&gap_query_seq, &gap_target_seq)?
         };
-        
+
         // Merge CIGARs
         let merged_cigar = if current.strand == '-' {
             merge_cigars(&[&eroded_next_cigar, &gap_cigar, &eroded_current_cigar])?
         } else {
             merge_cigars(&[&eroded_current_cigar, &gap_cigar, &eroded_next_cigar])?
         };
-        
+
         // Create the merged entry
-        merged_entry = create_merged_entry(
-            current, next, &merged_cigar
-        );
+        merged_entry = create_merged_entry(current, next, &merged_cigar);
     }
-    
-    debug!("\tMerged query {}-{}; {}; target {}-{}", merged_entry.query_start, merged_entry.query_end, merged_entry.strand, merged_entry.target_start, merged_entry.target_end);
+
+    debug!(
+        "\tMerged query {}-{}; {}; target {}-{}",
+        merged_entry.query_start,
+        merged_entry.query_end,
+        merged_entry.strand,
+        merged_entry.target_start,
+        merged_entry.target_end
+    );
 
     Ok(vec![merged_entry])
 }
 
-
 fn main() -> Result<(), Box<dyn Error>> {
     // Parse command-line arguments
     let args = Args::parse();
-    
+
     // Initialize logging
     env_logger::Builder::new()
         .filter_level(match args.verbose {
-            0 => log::LevelFilter::Warn,    // Errors and warnings
-            1 => log::LevelFilter::Info,    // Errors, warnings, and info
-            _ => log::LevelFilter::Debug,   // Errors, warnings, info, and debug
+            0 => log::LevelFilter::Warn,  // Errors and warnings
+            1 => log::LevelFilter::Info,  // Errors, warnings, and info
+            _ => log::LevelFilter::Debug, // Errors, warnings, info, and debug
         })
         .init();
-    
+
     // Configure thread pool
     rayon::ThreadPoolBuilder::new()
         .num_threads(args.threads.into())
         .build_global()?;
-    
+
     // Check for or build chain index
     let index_path = args.paf.with_extension("cidx"); // Chain index file
     let chain_index = if index_path.exists() {
@@ -841,20 +960,24 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Load sequence databases
     info!("Loading query sequences from {}...", args.query.display());
     let query_db = SequenceDB::new(&args.query)?;
-    
+
     info!("Loading target sequences from {}...", args.target.display());
     let target_db = SequenceDB::new(&args.target)?;
-       
+
     // Process each chain individually
     let mut processed_entries = Vec::new();
-    
+
     for chain_id in chain_index.get_chain_ids() {
         debug!("Processing chain {} ...", chain_id);
-        
+
         // Load chain entries for this specific chain only
         let chain_entries = chain_index.load_chain(chain_id)?;
-        debug!("Loaded {} entries for chain {}", chain_entries.len(), chain_id);
-        
+        debug!(
+            "Loaded {} entries for chain {}",
+            chain_entries.len(),
+            chain_id
+        );
+
         // Process chain and add results to the output
         let chain_result = process_chain(&chain_entries, &query_db, &target_db, args.erosion_size)?;
         processed_entries.extend(chain_result);
@@ -865,10 +988,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         Some(file_path) => {
             let file = File::create(file_path)?;
             Box::new(io::BufWriter::new(file)) as Box<dyn Write>
-        },
-        None => {
-            Box::new(io::BufWriter::new(io::stdout())) as Box<dyn Write>
         }
+        None => Box::new(io::BufWriter::new(io::stdout())) as Box<dyn Write>,
     };
 
     // Write output in appropriate format
@@ -877,7 +998,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     } else {
         write_paf_content(&mut writer, &processed_entries)?;
     }
-    
+
     info!("Done!");
     Ok(())
 }


### PR DESCRIPTION
This avoids loading the full PAF in memory. If the chain index does not exist, the input PAF is read, and the index is created and saved as a `.cidx` file. Only the chain to be concatenated is loaded completely into memory.