### PR TITLE
Homogenize cigar representation using `CigarOp`

### DIFF
--- a/src/cigar.rs
+++ b/src/cigar.rs
@@ -1,0 +1,305 @@
+use std::error::Error;
+
+use log::{debug};
+
+// CIGAR operation
+#[derive(Debug, Clone, Copy)]
+pub struct CigarOp(pub char, pub usize);
+
+// Parse CIGAR string into operations
+pub fn cigar_to_ops(cigar: &str) -> Result<Vec<CigarOp>, Box<dyn Error>> {
+    let mut ops = Vec::new();
+    let mut count = 0;
+
+    for c in cigar.chars() {
+        if c.is_digit(10) {
+            count = count * 10 + c.to_digit(10).unwrap() as usize;
+        } else {
+            ops.push(CigarOp(c, count));
+            count = 0;
+        }
+    }
+
+    if count > 0 {
+        return Err("CIGAR string ended with a number".into());
+    }
+
+    Ok(ops)
+}
+
+// Convert WFA alignment CIGAR to standard operations
+pub fn cigar_u8_to_ops(cigar: &[u8]) -> Vec<CigarOp> {
+    if cigar.is_empty() {
+        return Vec::new();
+    }
+
+    let mut ops = Vec::new();
+    let mut count = 0;
+    let mut last_op = cigar[0];
+
+    for &op in cigar {
+        if op == last_op {
+            count += 1;
+        } else {
+            // Convert the operation
+            let cigar_op = match last_op {
+                b'M' => '=', // Match
+                b'X' => 'X', // Mismatch
+                b'D' => 'D', // Deletion
+                b'I' => 'I', // Insertion
+                _ => panic!("Unknown CIGAR operation: {}", last_op),
+            };
+            ops.push(CigarOp(cigar_op, count));
+            count = 1;
+            last_op = op;
+        }
+    }
+
+    // Add the last operation
+    let cigar_op = match last_op {
+        b'M' => '=',
+        b'X' => 'X',
+        b'D' => 'D',
+        b'I' => 'I',
+        _ => panic!("Unknown CIGAR operation: {}", last_op),
+    };
+    ops.push(CigarOp(cigar_op, count));
+    ops
+}
+
+// Convert CIGAR operations to string
+pub fn ops_to_cigar(ops: &[CigarOp]) -> String {
+    ops.iter()
+        .map(|&CigarOp(op, count)| format!("{}{}", count, op))
+        .collect()
+}
+
+// Erode CIGAR from the end with separate query and target erosion limits
+pub fn erode_cigar_end(cigar_ops: &[CigarOp], query_bp_limit: usize, target_bp_limit: usize) -> Result<(Vec<CigarOp>, usize, usize), Box<dyn Error>> {
+    let mut new_ops = Vec::new();
+    let mut remaining_query_bp = query_bp_limit;
+    let mut remaining_target_bp = target_bp_limit;
+    let mut query_bases_removed = 0;
+    let mut target_bases_removed = 0;
+    
+    debug!("\tEroding from end of CIGAR - Query limit: {} bp, Target limit: {} bp", 
+          query_bp_limit, target_bp_limit);
+    
+    // Copy operations from beginning until we need to erode
+    let mut i = 0;
+    while i < cigar_ops.len() && (remaining_query_bp > 0 || remaining_target_bp > 0) {
+        // Process operations from the end
+        let idx = cigar_ops.len() - 1 - i;
+        let CigarOp(op, count) = cigar_ops[idx];
+        
+        match op {
+            '=' | 'X' | 'M' => {
+                // Advances both sequences
+                if remaining_query_bp > 0 || remaining_target_bp > 0 {
+                    let query_erosion = std::cmp::min(count, remaining_query_bp);
+                    let target_erosion = std::cmp::min(count, remaining_target_bp);
+                    
+                    // Determine actual erosion
+                    let actual_erosion = std::cmp::max(query_erosion, target_erosion);
+                    
+                    if actual_erosion < count {
+                        // Partial erosion
+                        new_ops.insert(0, CigarOp(op, count - actual_erosion));
+                    }
+                    
+                    query_bases_removed += actual_erosion;
+                    target_bases_removed += actual_erosion;
+                    remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
+                    remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
+                } else {
+                    // No more erosion needed
+                    new_ops.insert(0, CigarOp(op, count));
+                }
+            },
+            'I' => {
+                // Insertion only advances query
+                if remaining_query_bp > 0 {
+                    let actual_erosion = std::cmp::min(count, remaining_query_bp);
+                    
+                    if actual_erosion < count {
+                        // Partial erosion
+                        new_ops.insert(0, CigarOp(op, count - actual_erosion));
+                    }
+                    
+                    query_bases_removed += actual_erosion;
+                    remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
+                } else {
+                    // No more query erosion needed
+                    new_ops.insert(0, CigarOp(op, count));
+                }
+            },
+            'D' => {
+                // Deletion only advances target
+                if remaining_target_bp > 0 {
+                    let actual_erosion = std::cmp::min(count, remaining_target_bp);
+
+                    if actual_erosion < count {
+                        // Partial erosion
+                        new_ops.insert(0, CigarOp(op, count - actual_erosion));
+                    }
+                    
+                    target_bases_removed += actual_erosion;
+                    remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
+                } else {
+                    // No more target erosion needed
+                    new_ops.insert(0, CigarOp(op, count));
+                }
+            },
+            _ => new_ops.insert(0, CigarOp(op, count)), // Keep other operations
+        }
+        
+        i += 1;
+    }
+    
+    // Add remaining operations
+    for j in 0..(cigar_ops.len() - i) {
+        new_ops.insert(j, cigar_ops[j]);
+    }
+    
+    Ok((new_ops, query_bases_removed, target_bases_removed))
+}
+
+// Erode CIGAR from the start with separate query and target erosion limits
+pub fn erode_cigar_start(cigar_ops: &[CigarOp], query_bp_limit: usize, target_bp_limit: usize) -> Result<(Vec<CigarOp>, usize, usize), Box<dyn Error>> {
+    let mut new_ops = Vec::new();
+    let mut remaining_query_bp = query_bp_limit;
+    let mut remaining_target_bp = target_bp_limit;
+    let mut query_bases_removed = 0;
+    let mut target_bases_removed = 0;
+    
+    debug!("\tEroding from start of CIGAR - Query limit: {} bp, Target limit: {} bp", 
+          query_bp_limit, target_bp_limit);
+    
+    // Skip or partially include first operations until eroded enough
+    let mut i = 0;
+    while i < cigar_ops.len() && (remaining_query_bp > 0 || remaining_target_bp > 0) {
+        let CigarOp(op, count) = cigar_ops[i];
+        
+        match op {
+            '=' | 'X' | 'M' => {
+                // Advances both sequences
+                if remaining_query_bp > 0 || remaining_target_bp > 0 {
+                    let query_erosion = std::cmp::min(count, remaining_query_bp);
+                    let target_erosion = std::cmp::min(count, remaining_target_bp);
+                    
+                    // Determine actual erosion
+                    let actual_erosion = std::cmp::max(query_erosion, target_erosion);
+
+                    if actual_erosion < count {
+                        // Partial erosion
+                        new_ops.push(CigarOp(op, count - actual_erosion));
+                    }
+                    
+                    query_bases_removed += actual_erosion;
+                    target_bases_removed += actual_erosion;
+                    remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
+                    remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
+                } else {
+                    // No more erosion needed
+                    new_ops.push(CigarOp(op, count));
+                }
+            },
+            'I' => {
+                // Insertion only advances query
+                if remaining_query_bp > 0 {
+                    let actual_erosion = std::cmp::min(count, remaining_query_bp);
+                    
+                    if actual_erosion < count {
+                        // Partial erosion
+                        new_ops.push(CigarOp(op, count - actual_erosion));
+                    }
+                    
+                    query_bases_removed += actual_erosion;
+                    remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
+                } else {
+                    // No more query erosion needed
+                    new_ops.push(CigarOp(op, count));
+                }
+            },
+            'D' => {
+                // Deletion only advances target
+                if remaining_target_bp > 0 {
+                    let actual_erosion = std::cmp::min(count, remaining_target_bp);
+                    
+                    if actual_erosion < count {
+                        // Partial erosion
+                        new_ops.push(CigarOp(op, count - actual_erosion));
+                    }
+                    
+                    target_bases_removed += actual_erosion;
+                    remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
+                } else {
+                    // No more target erosion needed
+                    new_ops.push(CigarOp(op, count));
+                }
+            },
+            _ => new_ops.push(CigarOp(op, count)), // Keep other operations
+        }
+        
+        i += 1;
+    }
+    
+    // Add all remaining operations
+    while i < cigar_ops.len() {
+        new_ops.push(cigar_ops[i]);
+        i += 1;
+    }
+    
+    Ok((new_ops, query_bases_removed, target_bases_removed))
+}
+
+// Merge multiple CIGAR operations vectors
+pub fn merge_cigar_ops(cigar_ops_list: &[&[CigarOp]]) -> Result<Vec<CigarOp>, Box<dyn Error>> {
+    let mut all_ops = Vec::new();
+    
+    // Collect all operations
+    for &cigar_ops in cigar_ops_list {
+        all_ops.extend_from_slice(cigar_ops);
+    }
+    
+    // Optimize by combining adjacent operations of the same type
+    let mut optimized_ops = Vec::new();
+    let mut current_op = None;
+    
+    for &op in all_ops.iter() {
+        if let Some(CigarOp(prev_op, prev_count)) = current_op {
+            if prev_op == op.0 {
+                current_op = Some(CigarOp(prev_op, prev_count + op.1));
+            } else {
+                optimized_ops.push(CigarOp(prev_op, prev_count));
+                current_op = Some(op);
+            }
+        } else {
+            current_op = Some(op);
+        }
+    }
+    
+    if let Some(op) = current_op {
+        optimized_ops.push(op);
+    }
+    
+    Ok(optimized_ops)
+}
+
+// Calculate CIGAR statistics
+pub fn calculate_cigar_stats(cigar_ops: &[CigarOp]) -> Result<(u64, u64, u64, u64, u64, u64, u64), Box<dyn Error>> {
+    let (matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len) = 
+        cigar_ops.iter().fold((0, 0, 0, 0, 0, 0, 0), |(m, mm, i, i_bp, d, d_bp, bl), &CigarOp(op, len)| {
+            let len = len as u64;
+            match op {
+                'M' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
+                '=' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
+                'X' => (m, mm + len, i, i_bp, d, d_bp, bl + len),
+                'I' => (m, mm, i + 1, i_bp + len, d, d_bp, bl + len),
+                'D' => (m, mm, i, i_bp, d + 1, d_bp + len, bl + len),
+                _ => (m, mm, i, i_bp, d, d_bp, bl),
+            }
+        });
+    
+    Ok((matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len))
+}

--- a/src/cigar.rs
+++ b/src/cigar.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use log::{debug};
+use log::debug;
 
 // CIGAR operation
 #[derive(Debug, Clone, Copy)]
@@ -75,38 +75,44 @@ pub fn ops_to_cigar(ops: &[CigarOp]) -> String {
 }
 
 // Erode CIGAR from the end with separate query and target erosion limits
-pub fn erode_cigar_end(cigar_ops: &[CigarOp], query_bp_limit: usize, target_bp_limit: usize) -> Result<(Vec<CigarOp>, usize, usize), Box<dyn Error>> {
+pub fn erode_cigar_end(
+    cigar_ops: &[CigarOp],
+    query_bp_limit: usize,
+    target_bp_limit: usize,
+) -> Result<(Vec<CigarOp>, usize, usize), Box<dyn Error>> {
     let mut new_ops = Vec::new();
     let mut remaining_query_bp = query_bp_limit;
     let mut remaining_target_bp = target_bp_limit;
     let mut query_bases_removed = 0;
     let mut target_bases_removed = 0;
-    
-    debug!("\tEroding from end of CIGAR - Query limit: {} bp, Target limit: {} bp", 
-          query_bp_limit, target_bp_limit);
-    
+
+    debug!(
+        "\tEroding from end of CIGAR - Query limit: {} bp, Target limit: {} bp",
+        query_bp_limit, target_bp_limit
+    );
+
     // Copy operations from beginning until we need to erode
     let mut i = 0;
     while i < cigar_ops.len() && (remaining_query_bp > 0 || remaining_target_bp > 0) {
         // Process operations from the end
         let idx = cigar_ops.len() - 1 - i;
         let CigarOp(op, count) = cigar_ops[idx];
-        
+
         match op {
             '=' | 'X' | 'M' => {
                 // Advances both sequences
                 if remaining_query_bp > 0 || remaining_target_bp > 0 {
                     let query_erosion = std::cmp::min(count, remaining_query_bp);
                     let target_erosion = std::cmp::min(count, remaining_target_bp);
-                    
+
                     // Determine actual erosion
                     let actual_erosion = std::cmp::max(query_erosion, target_erosion);
-                    
+
                     if actual_erosion < count {
                         // Partial erosion
                         new_ops.insert(0, CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     query_bases_removed += actual_erosion;
                     target_bases_removed += actual_erosion;
                     remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
@@ -115,24 +121,24 @@ pub fn erode_cigar_end(cigar_ops: &[CigarOp], query_bp_limit: usize, target_bp_l
                     // No more erosion needed
                     new_ops.insert(0, CigarOp(op, count));
                 }
-            },
+            }
             'I' => {
                 // Insertion only advances query
                 if remaining_query_bp > 0 {
                     let actual_erosion = std::cmp::min(count, remaining_query_bp);
-                    
+
                     if actual_erosion < count {
                         // Partial erosion
                         new_ops.insert(0, CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     query_bases_removed += actual_erosion;
                     remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
                 } else {
                     // No more query erosion needed
                     new_ops.insert(0, CigarOp(op, count));
                 }
-            },
+            }
             'D' => {
                 // Deletion only advances target
                 if remaining_target_bp > 0 {
@@ -142,51 +148,57 @@ pub fn erode_cigar_end(cigar_ops: &[CigarOp], query_bp_limit: usize, target_bp_l
                         // Partial erosion
                         new_ops.insert(0, CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     target_bases_removed += actual_erosion;
                     remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
                 } else {
                     // No more target erosion needed
                     new_ops.insert(0, CigarOp(op, count));
                 }
-            },
+            }
             _ => new_ops.insert(0, CigarOp(op, count)), // Keep other operations
         }
-        
+
         i += 1;
     }
-    
+
     // Add remaining operations
     for j in 0..(cigar_ops.len() - i) {
         new_ops.insert(j, cigar_ops[j]);
     }
-    
+
     Ok((new_ops, query_bases_removed, target_bases_removed))
 }
 
 // Erode CIGAR from the start with separate query and target erosion limits
-pub fn erode_cigar_start(cigar_ops: &[CigarOp], query_bp_limit: usize, target_bp_limit: usize) -> Result<(Vec<CigarOp>, usize, usize), Box<dyn Error>> {
+pub fn erode_cigar_start(
+    cigar_ops: &[CigarOp],
+    query_bp_limit: usize,
+    target_bp_limit: usize,
+) -> Result<(Vec<CigarOp>, usize, usize), Box<dyn Error>> {
     let mut new_ops = Vec::new();
     let mut remaining_query_bp = query_bp_limit;
     let mut remaining_target_bp = target_bp_limit;
     let mut query_bases_removed = 0;
     let mut target_bases_removed = 0;
-    
-    debug!("\tEroding from start of CIGAR - Query limit: {} bp, Target limit: {} bp", 
-          query_bp_limit, target_bp_limit);
-    
+
+    debug!(
+        "\tEroding from start of CIGAR - Query limit: {} bp, Target limit: {} bp",
+        query_bp_limit, target_bp_limit
+    );
+
     // Skip or partially include first operations until eroded enough
     let mut i = 0;
     while i < cigar_ops.len() && (remaining_query_bp > 0 || remaining_target_bp > 0) {
         let CigarOp(op, count) = cigar_ops[i];
-        
+
         match op {
             '=' | 'X' | 'M' => {
                 // Advances both sequences
                 if remaining_query_bp > 0 || remaining_target_bp > 0 {
                     let query_erosion = std::cmp::min(count, remaining_query_bp);
                     let target_erosion = std::cmp::min(count, remaining_target_bp);
-                    
+
                     // Determine actual erosion
                     let actual_erosion = std::cmp::max(query_erosion, target_erosion);
 
@@ -194,7 +206,7 @@ pub fn erode_cigar_start(cigar_ops: &[CigarOp], query_bp_limit: usize, target_bp
                         // Partial erosion
                         new_ops.push(CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     query_bases_removed += actual_erosion;
                     target_bases_removed += actual_erosion;
                     remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
@@ -203,69 +215,69 @@ pub fn erode_cigar_start(cigar_ops: &[CigarOp], query_bp_limit: usize, target_bp
                     // No more erosion needed
                     new_ops.push(CigarOp(op, count));
                 }
-            },
+            }
             'I' => {
                 // Insertion only advances query
                 if remaining_query_bp > 0 {
                     let actual_erosion = std::cmp::min(count, remaining_query_bp);
-                    
+
                     if actual_erosion < count {
                         // Partial erosion
                         new_ops.push(CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     query_bases_removed += actual_erosion;
                     remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
                 } else {
                     // No more query erosion needed
                     new_ops.push(CigarOp(op, count));
                 }
-            },
+            }
             'D' => {
                 // Deletion only advances target
                 if remaining_target_bp > 0 {
                     let actual_erosion = std::cmp::min(count, remaining_target_bp);
-                    
+
                     if actual_erosion < count {
                         // Partial erosion
                         new_ops.push(CigarOp(op, count - actual_erosion));
                     }
-                    
+
                     target_bases_removed += actual_erosion;
                     remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
                 } else {
                     // No more target erosion needed
                     new_ops.push(CigarOp(op, count));
                 }
-            },
+            }
             _ => new_ops.push(CigarOp(op, count)), // Keep other operations
         }
-        
+
         i += 1;
     }
-    
+
     // Add all remaining operations
     while i < cigar_ops.len() {
         new_ops.push(cigar_ops[i]);
         i += 1;
     }
-    
+
     Ok((new_ops, query_bases_removed, target_bases_removed))
 }
 
 // Merge multiple CIGAR operations vectors
 pub fn merge_cigar_ops(cigar_ops_list: &[&[CigarOp]]) -> Result<Vec<CigarOp>, Box<dyn Error>> {
     let mut all_ops = Vec::new();
-    
+
     // Collect all operations
     for &cigar_ops in cigar_ops_list {
         all_ops.extend_from_slice(cigar_ops);
     }
-    
+
     // Optimize by combining adjacent operations of the same type
     let mut optimized_ops = Vec::new();
     let mut current_op = None;
-    
+
     for &op in all_ops.iter() {
         if let Some(CigarOp(prev_op, prev_count)) = current_op {
             if prev_op == op.0 {
@@ -278,28 +290,41 @@ pub fn merge_cigar_ops(cigar_ops_list: &[&[CigarOp]]) -> Result<Vec<CigarOp>, Bo
             current_op = Some(op);
         }
     }
-    
+
     if let Some(op) = current_op {
         optimized_ops.push(op);
     }
-    
+
     Ok(optimized_ops)
 }
 
 // Calculate CIGAR statistics
-pub fn calculate_cigar_stats(cigar_ops: &[CigarOp]) -> Result<(u64, u64, u64, u64, u64, u64, u64), Box<dyn Error>> {
-    let (matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len) = 
-        cigar_ops.iter().fold((0, 0, 0, 0, 0, 0, 0), |(m, mm, i, i_bp, d, d_bp, bl), &CigarOp(op, len)| {
-            let len = len as u64;
-            match op {
-                'M' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
-                '=' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
-                'X' => (m, mm + len, i, i_bp, d, d_bp, bl + len),
-                'I' => (m, mm, i + 1, i_bp + len, d, d_bp, bl + len),
-                'D' => (m, mm, i, i_bp, d + 1, d_bp + len, bl + len),
-                _ => (m, mm, i, i_bp, d, d_bp, bl),
-            }
-        });
-    
-    Ok((matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len))
+pub fn calculate_cigar_stats(
+    cigar_ops: &[CigarOp],
+) -> Result<(u64, u64, u64, u64, u64, u64, u64), Box<dyn Error>> {
+    let (matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len) =
+        cigar_ops.iter().fold(
+            (0, 0, 0, 0, 0, 0, 0),
+            |(m, mm, i, i_bp, d, d_bp, bl), &CigarOp(op, len)| {
+                let len = len as u64;
+                match op {
+                    'M' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
+                    '=' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
+                    'X' => (m, mm + len, i, i_bp, d, d_bp, bl + len),
+                    'I' => (m, mm, i + 1, i_bp + len, d, d_bp, bl + len),
+                    'D' => (m, mm, i, i_bp, d + 1, d_bp + len, bl + len),
+                    _ => (m, mm, i, i_bp, d, d_bp, bl),
+                }
+            },
+        );
+
+    Ok((
+        matches,
+        mismatches,
+        insertions,
+        inserted_bp,
+        deletions,
+        deleted_bp,
+        block_len,
+    ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,2 @@
-pub mod cigar;
 pub mod chain_index;
+pub mod cigar;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod cigar;
 pub mod chain_index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 use pafchainer::chain_index::{ChainIndex, PafEntry};
+use pafchainer::cigar::{CigarOp, cigar_u8_to_ops, ops_to_cigar, erode_cigar_end, erode_cigar_start, calculate_cigar_stats, merge_cigar_ops};
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -51,10 +52,6 @@ struct Args {
     #[clap(short, long, default_value = "0")]
     verbose: u8,
 }
-
-// CIGAR operation
-#[derive(Debug, Clone, Copy)]
-struct CigarOp(char, usize);
 
 // Sequence database to handle FASTA files
 struct SequenceDB {
@@ -112,280 +109,8 @@ impl SequenceDB {
     }
 }
 
-// Parse CIGAR string into operations
-fn cigar_to_ops(cigar: &str) -> Result<Vec<CigarOp>, Box<dyn Error>> {
-    let mut ops = Vec::new();
-    let mut count = 0;
-
-    for c in cigar.chars() {
-        if c.is_digit(10) {
-            count = count * 10 + c.to_digit(10).unwrap() as usize;
-        } else {
-            ops.push(CigarOp(c, count));
-            count = 0;
-        }
-    }
-
-    if count > 0 {
-        return Err("CIGAR string ended with a number".into());
-    }
-
-    Ok(ops)
-}
-
-// Convert WFA alignment CIGAR to standard operations
-fn cigar_u8_to_ops(cigar: &[u8]) -> Vec<(usize, char)> {
-    if cigar.is_empty() {
-        return Vec::new();
-    }
-
-    let mut ops = Vec::new();
-    let mut count = 0;
-    let mut last_op = cigar[0];
-
-    for &op in cigar {
-        if op == last_op {
-            count += 1;
-        } else {
-            // Convert the operation
-            let cigar_op = match last_op {
-                b'M' => '=', // Match
-                b'X' => 'X', // Mismatch
-                b'D' => 'D', // Deletion
-                b'I' => 'I', // Insertion
-                _ => panic!("Unknown CIGAR operation: {}", last_op),
-            };
-            ops.push((count, cigar_op));
-            count = 1;
-            last_op = op;
-        }
-    }
-
-    // Add the last operation
-    let cigar_op = match last_op {
-        b'M' => '=',
-        b'X' => 'X',
-        b'D' => 'D',
-        b'I' => 'I',
-        _ => panic!("Unknown CIGAR operation: {}", last_op),
-    };
-    ops.push((count, cigar_op));
-
-    ops
-}
-
-// Convert CIGAR operations to string
-fn ops_to_cigar(ops: &[CigarOp]) -> String {
-    ops.iter()
-        .map(|&CigarOp(op, count)| format!("{}{}", count, op))
-        .collect()
-}
-
-// Erode CIGAR from the end with separate query and target erosion limits
-fn erode_cigar_end(
-    cigar: &str,
-    query_bp_limit: usize,
-    target_bp_limit: usize,
-) -> Result<(String, usize, usize), Box<dyn Error>> {
-    let ops = cigar_to_ops(cigar)?;
-    let mut new_ops = Vec::new();
-    let mut remaining_query_bp = query_bp_limit;
-    let mut remaining_target_bp = target_bp_limit;
-    let mut query_bases_removed = 0;
-    let mut target_bases_removed = 0;
-
-    debug!(
-        "\tEroding from end of CIGAR - Query limit: {} bp, Target limit: {} bp",
-        query_bp_limit, target_bp_limit
-    );
-
-    // Copy operations from beginning until we need to erode
-    let mut i = 0;
-    while i < ops.len() && (remaining_query_bp > 0 || remaining_target_bp > 0) {
-        // Process operations from the end
-        let idx = ops.len() - 1 - i;
-        let CigarOp(op, count) = ops[idx];
-
-        // debug!("\t\terode_cigar_end - Processing operation: {}{}", count, op);
-
-        match op {
-            '=' | 'X' | 'M' => {
-                // Advances both sequences
-                if remaining_query_bp > 0 || remaining_target_bp > 0 {
-                    let query_erosion = std::cmp::min(count, remaining_query_bp);
-                    let target_erosion = std::cmp::min(count, remaining_target_bp);
-
-                    // Determine actual erosion
-                    let actual_erosion = std::cmp::max(query_erosion, target_erosion);
-
-                    if actual_erosion < count {
-                        // Partial erosion
-                        new_ops.insert(0, CigarOp(op, count - actual_erosion));
-                    }
-
-                    query_bases_removed += actual_erosion;
-                    target_bases_removed += actual_erosion;
-                    remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
-                    remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
-                } else {
-                    // No more erosion needed
-                    new_ops.insert(0, CigarOp(op, count));
-                }
-            }
-            'I' => {
-                // Insertion only advances query
-                if remaining_query_bp > 0 {
-                    let actual_erosion = count;
-
-                    query_bases_removed += actual_erosion;
-                    remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
-                } else {
-                    // No more query erosion needed
-                    new_ops.insert(0, CigarOp(op, count));
-                }
-            }
-            'D' => {
-                // Deletion only advances target
-                if remaining_target_bp > 0 {
-                    let actual_erosion = count;
-
-                    target_bases_removed += actual_erosion;
-                    remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
-                } else {
-                    // No more target erosion needed
-                    new_ops.insert(0, CigarOp(op, count));
-                }
-            }
-            _ => new_ops.insert(0, CigarOp(op, count)), // Keep other operations
-        }
-
-        i += 1;
-
-        // debug!("\t\tProgress - Eroded from query: {}/{}, target: {}/{}",
-        //       query_bases_removed, query_bp_limit,
-        //       target_bases_removed, target_bp_limit);
-    }
-
-    // Add remaining operations
-    for j in 0..(ops.len() - i) {
-        new_ops.insert(j, ops[j]);
-    }
-
-    Ok((
-        ops_to_cigar(&new_ops),
-        query_bases_removed,
-        target_bases_removed,
-    ))
-}
-
-// Erode CIGAR from the start with separate query and target erosion limits
-fn erode_cigar_start(
-    cigar: &str,
-    query_bp_limit: usize,
-    target_bp_limit: usize,
-) -> Result<(String, usize, usize), Box<dyn Error>> {
-    let ops = cigar_to_ops(cigar)?;
-    let mut new_ops = Vec::new();
-    let mut remaining_query_bp = query_bp_limit;
-    let mut remaining_target_bp = target_bp_limit;
-    let mut query_bases_removed = 0;
-    let mut target_bases_removed = 0;
-
-    debug!(
-        "\tEroding from start of CIGAR - Query limit: {} bp, Target limit: {} bp",
-        query_bp_limit, target_bp_limit
-    );
-
-    // Skip or partially include first operations until eroded enough
-    let mut i = 0;
-    while i < ops.len() && (remaining_query_bp > 0 || remaining_target_bp > 0) {
-        let CigarOp(op, count) = ops[i];
-
-        // debug!("\t\terode_cigar_start - Processing operation: {}{}", count, op);
-
-        match op {
-            '=' | 'X' | 'M' => {
-                // Advances both sequences
-                if remaining_query_bp > 0 || remaining_target_bp > 0 {
-                    let query_erosion = std::cmp::min(count, remaining_query_bp);
-                    let target_erosion = std::cmp::min(count, remaining_target_bp);
-
-                    // Determine actual erosion
-                    let actual_erosion = std::cmp::max(query_erosion, target_erosion);
-
-                    if actual_erosion < count {
-                        // Partial erosion
-                        new_ops.push(CigarOp(op, count - actual_erosion));
-                    }
-
-                    query_bases_removed += actual_erosion;
-                    target_bases_removed += actual_erosion;
-                    remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
-                    remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
-                } else {
-                    // No more erosion needed
-                    new_ops.push(CigarOp(op, count));
-                }
-            }
-            'I' => {
-                // Insertion only advances query
-                if remaining_query_bp > 0 {
-                    let actual_erosion = std::cmp::min(count, remaining_query_bp);
-
-                    if actual_erosion < count {
-                        // Partial erosion
-                        new_ops.push(CigarOp(op, count - actual_erosion));
-                    }
-
-                    query_bases_removed += actual_erosion;
-                    remaining_query_bp = remaining_query_bp.saturating_sub(actual_erosion);
-                } else {
-                    // No more query erosion needed
-                    new_ops.push(CigarOp(op, count));
-                }
-            }
-            'D' => {
-                // Deletion only advances target
-                if remaining_target_bp > 0 {
-                    let actual_erosion = std::cmp::min(count, remaining_target_bp);
-
-                    if actual_erosion < count {
-                        // Partial erosion
-                        new_ops.push(CigarOp(op, count - actual_erosion));
-                    }
-
-                    target_bases_removed += actual_erosion;
-                    remaining_target_bp = remaining_target_bp.saturating_sub(actual_erosion);
-                } else {
-                    // No more target erosion needed
-                    new_ops.push(CigarOp(op, count));
-                }
-            }
-            _ => new_ops.push(CigarOp(op, count)), // Keep other operations
-        }
-
-        i += 1;
-
-        // debug!("\t\tProgress - Eroded from query: {}/{}, target: {}/{}",
-        //       query_bases_removed, query_bp_limit,
-        //       target_bases_removed, target_bp_limit);
-    }
-
-    // Add all remaining operations
-    while i < ops.len() {
-        new_ops.push(ops[i]);
-        i += 1;
-    }
-
-    Ok((
-        ops_to_cigar(&new_ops),
-        query_bases_removed,
-        target_bases_removed,
-    ))
-}
-
 // Align two sequences using WFA
-fn align_sequences_wfa(query: &[u8], target: &[u8]) -> Result<String, Box<dyn Error>> {
+fn align_sequences_wfa(query: &[u8], target: &[u8]) -> Result<Vec<CigarOp>, Box<dyn Error>> {
     debug!(
         "Performing WFA alignment between sequences of lengths {} and {}",
         query.len(),
@@ -423,80 +148,9 @@ fn align_sequences_wfa(query: &[u8], target: &[u8]) -> Result<String, Box<dyn Er
         }
     }
 
-    // Convert CIGAR to string
+    // Convert CIGAR to CigarOps
     let cigar_ops = cigar_u8_to_ops(aligner.cigar());
-    let cigar = cigar_ops
-        .iter()
-        .map(|(count, op)| format!("{}{}", count, op))
-        .collect::<String>();
-
-    Ok(cigar)
-}
-
-// Merge multiple CIGAR strings
-fn merge_cigars(cigars: &[&str]) -> Result<String, Box<dyn Error>> {
-    let mut all_ops = Vec::new();
-
-    // Collect all operations
-    for &cigar in cigars {
-        let ops = cigar_to_ops(cigar)?;
-        all_ops.extend_from_slice(&ops);
-    }
-
-    // Optimize by combining adjacent operations of the same type
-    let mut optimized_ops = Vec::new();
-    let mut current_op = None;
-
-    for op in all_ops {
-        if let Some(CigarOp(prev_op, prev_count)) = current_op {
-            if prev_op == op.0 {
-                current_op = Some(CigarOp(prev_op, prev_count + op.1));
-            } else {
-                optimized_ops.push(CigarOp(prev_op, prev_count));
-                current_op = Some(op);
-            }
-        } else {
-            current_op = Some(op);
-        }
-    }
-
-    if let Some(op) = current_op {
-        optimized_ops.push(op);
-    }
-
-    Ok(ops_to_cigar(&optimized_ops))
-}
-
-// Calculate CIGAR statistics
-fn calculate_cigar_stats(
-    cigar: &str,
-) -> Result<(u64, u64, u64, u64, u64, u64, u64), Box<dyn Error>> {
-    let ops = cigar_to_ops(cigar)?;
-    let (matches, mismatches, insertions, inserted_bp, deletions, deleted_bp, block_len) =
-        ops.iter().fold(
-            (0, 0, 0, 0, 0, 0, 0),
-            |(m, mm, i, i_bp, d, d_bp, bl), &CigarOp(op, len)| {
-                let len = len as u64;
-                match op {
-                    'M' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
-                    '=' => (m + len, mm, i, i_bp, d, d_bp, bl + len),
-                    'X' => (m, mm + len, i, i_bp, d, d_bp, bl + len),
-                    'I' => (m, mm, i + 1, i_bp + len, d, d_bp, bl + len),
-                    'D' => (m, mm, i, i_bp, d + 1, d_bp + len, bl + len),
-                    _ => (m, mm, i, i_bp, d, d_bp, bl),
-                }
-            },
-        );
-
-    Ok((
-        matches,
-        mismatches,
-        insertions,
-        inserted_bp,
-        deletions,
-        deleted_bp,
-        block_len,
-    ))
+    Ok(cigar_ops)
 }
 
 // Write PAF entries to a writer
@@ -548,8 +202,6 @@ fn paf_entry_to_sam(
         None => "*".to_string(),
     };
 
-    let sam_cigar = &entry.cigar;
-
     // Fetch sequence
     let sequence = query_db.get_subsequence(
         &entry.query_name,
@@ -578,7 +230,7 @@ fn paf_entry_to_sam(
     ));
 
     // Add NM tag (edit distance)
-    let (matches, mismatches, _, ins_bp, _, del_bp, _) = calculate_cigar_stats(&entry.cigar)?;
+    let (matches, mismatches, _, ins_bp, _, del_bp, _) = calculate_cigar_stats(&entry.cigar_ops)?;
     let edit_distance = mismatches + ins_bp + del_bp;
     optional_fields.push(format!("NM:i:{}", edit_distance));
 
@@ -596,7 +248,7 @@ fn paf_entry_to_sam(
         ref_id,
         entry.target_start + 1, // SAM is 1-based
         mapq,
-        sam_cigar,
+        ops_to_cigar(&entry.cigar_ops),
         tlen,
         seq_str,
         optional_fields.join("\t")
@@ -637,11 +289,11 @@ fn write_sam_content<W: Write>(
 }
 
 // Helper function to update tags in a PafEntry
-fn update_tags(tags: &[(String, String)], cigar: &str, chain_id: u64) -> Vec<(String, String)> {
+fn update_tags(tags: &[(String, String)], cigar_ops: &[CigarOp], chain_id: u64) -> Vec<(String, String)> {
     let mut new_tags = Vec::with_capacity(tags.len());
     for (tag, value) in tags {
         if tag == "cg:Z" {
-            new_tags.push((tag.clone(), cigar.to_string()));
+            new_tags.push((tag.clone(), ops_to_cigar(cigar_ops)));
         } else if tag == "ch:Z" {
             new_tags.push((tag.clone(), format!("{}.1.1", chain_id)));
         } else {
@@ -655,11 +307,11 @@ fn update_tags(tags: &[(String, String)], cigar: &str, chain_id: u64) -> Vec<(St
 fn create_merged_entry(
     base_entry: &PafEntry,
     next_entry: &PafEntry,
-    merged_cigar: &str,
+    merged_ops: &[CigarOp]
 ) -> PafEntry {
     // Calculate statistics from merged CIGAR
     let (matches, _, _, _, _, _, block_len) =
-        calculate_cigar_stats(merged_cigar).expect("Failed to calculate CIGAR stats");
+        calculate_cigar_stats(merged_ops).expect("Failed to calculate CIGAR stats");
 
     // Adjust target range based on strand
     let (adjusted_target_start, adjusted_target_end) = if base_entry.strand == '-' {
@@ -682,11 +334,11 @@ fn create_merged_entry(
         num_matches: matches,
         alignment_length: block_len,
         mapping_quality: base_entry.mapping_quality,
-        tags: update_tags(&base_entry.tags, merged_cigar, base_entry.chain_id),
+        tags: update_tags(&base_entry.tags, merged_ops, base_entry.chain_id),
         chain_id: base_entry.chain_id,
         chain_length: 1,
         chain_pos: 1,
-        cigar: merged_cigar.to_string(),
+        cigar_ops: merged_ops.to_vec(),
     }
 }
 
@@ -796,25 +448,25 @@ fn process_chain(
         };
 
         // Erode CIGARs at boundaries with the effective erosion sizes
-        let (eroded_current_cigar, current_query_removed, current_target_removed) =
+        let (eroded_current_cigar_ops, current_query_removed, current_target_removed) =
             if min_query_erosion_size > 0 || min_target_erosion_size > 0 {
                 if current.strand == '-' {
                     // For reverse strand, erode the start of the current entry
                     erode_cigar_start(
-                        &current.cigar,
+                        &current.cigar_ops,
                         min_query_erosion_size,
                         min_target_erosion_size,
                     )?
                 } else {
                     // For forward strand, erode the end of the current entry
                     erode_cigar_end(
-                        &current.cigar,
+                        &current.cigar_ops,
                         min_query_erosion_size,
                         min_target_erosion_size,
                     )?
                 }
             } else {
-                (current.cigar.clone(), 0, 0)
+                (current.cigar_ops.clone(), 0, 0)
             };
         debug!(
             "\tEroded CIGARs - Current: query: {}, target: {}",
@@ -823,19 +475,19 @@ fn process_chain(
 
         // Only erode the start of next entry if there's no overlap
         // (otherwise we've already handled the overlap by eroding the current entry)
-        let (eroded_next_cigar, next_query_removed, next_target_removed) =
+        let (eroded_next_cigar_ops, next_query_removed, next_target_removed) =
             if (min_query_erosion_size > 0 && query_overlap == 0)
                 || (min_target_erosion_size > 0 && target_overlap == 0)
             {
                 if current.strand == '-' {
                     // For reverse strand, erode the end of the next entry
-                    erode_cigar_end(&next.cigar, min_query_erosion_size, min_target_erosion_size)?
+                    erode_cigar_end(&next.cigar_ops, min_query_erosion_size, min_target_erosion_size)?
                 } else {
                     // For forward strand, erode the start of the next entry
-                    erode_cigar_start(&next.cigar, min_query_erosion_size, min_target_erosion_size)?
+                    erode_cigar_start(&next.cigar_ops, min_query_erosion_size, min_target_erosion_size)?
                 }
             } else {
-                (next.cigar.clone(), 0, 0)
+                (next.cigar_ops.clone(), 0, 0)
             };
         debug!(
             "\tEroded CIGARs - Next: query: {}, target: {}",
@@ -872,17 +524,17 @@ fn process_chain(
             query_gap, target_gap
         );
 
-        // Fetch sequences for alignment
-        let gap_cigar = if query_gap == 0 && target_gap == 0 {
+        // Generate gap CIGAR operations
+        let gap_ops = if query_gap == 0 && target_gap == 0 {
             // No gaps after erosion, nothing to align
-            String::new()
+            Vec::new()
         } else if query_gap > 0 && target_gap == 0 {
             // Query gap only - add insertion
-            format!("{}I", query_gap)
+            vec![CigarOp('I', query_gap as usize)]
         } else if query_gap == 0 && target_gap > 0 {
             // Target gap only - add deletion
-            format!("{}D", target_gap)
-        } else {
+            vec![CigarOp('D', target_gap as usize)]
+        } else { 
             // Both query and target have gaps - perform alignment
             let gap_query_seq = query_db.get_subsequence(
                 &current.query_name,
@@ -904,9 +556,9 @@ fn process_chain(
 
         // Merge CIGARs
         let merged_cigar = if current.strand == '-' {
-            merge_cigars(&[&eroded_next_cigar, &gap_cigar, &eroded_current_cigar])?
+            merge_cigar_ops(&[&eroded_next_cigar_ops, &gap_ops, &eroded_current_cigar_ops])?
         } else {
-            merge_cigars(&[&eroded_current_cigar, &gap_cigar, &eroded_next_cigar])?
+            merge_cigar_ops(&[&eroded_current_cigar_ops, &gap_ops, &eroded_next_cigar_ops])?
         };
 
         // Create the merged entry

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,10 @@ use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 
 use pafchainer::chain_index::{ChainIndex, PafEntry};
-use pafchainer::cigar::{CigarOp, cigar_u8_to_ops, ops_to_cigar, erode_cigar_end, erode_cigar_start, calculate_cigar_stats, merge_cigar_ops};
+use pafchainer::cigar::{
+    calculate_cigar_stats, cigar_u8_to_ops, erode_cigar_end, erode_cigar_start, merge_cigar_ops,
+    ops_to_cigar, CigarOp,
+};
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -289,7 +292,11 @@ fn write_sam_content<W: Write>(
 }
 
 // Helper function to update tags in a PafEntry
-fn update_tags(tags: &[(String, String)], cigar_ops: &[CigarOp], chain_id: u64) -> Vec<(String, String)> {
+fn update_tags(
+    tags: &[(String, String)],
+    cigar_ops: &[CigarOp],
+    chain_id: u64,
+) -> Vec<(String, String)> {
     let mut new_tags = Vec::with_capacity(tags.len());
     for (tag, value) in tags {
         if tag == "cg:Z" {
@@ -307,7 +314,7 @@ fn update_tags(tags: &[(String, String)], cigar_ops: &[CigarOp], chain_id: u64) 
 fn create_merged_entry(
     base_entry: &PafEntry,
     next_entry: &PafEntry,
-    merged_ops: &[CigarOp]
+    merged_ops: &[CigarOp],
 ) -> PafEntry {
     // Calculate statistics from merged CIGAR
     let (matches, _, _, _, _, _, block_len) =
@@ -481,10 +488,18 @@ fn process_chain(
             {
                 if current.strand == '-' {
                     // For reverse strand, erode the end of the next entry
-                    erode_cigar_end(&next.cigar_ops, min_query_erosion_size, min_target_erosion_size)?
+                    erode_cigar_end(
+                        &next.cigar_ops,
+                        min_query_erosion_size,
+                        min_target_erosion_size,
+                    )?
                 } else {
                     // For forward strand, erode the start of the next entry
-                    erode_cigar_start(&next.cigar_ops, min_query_erosion_size, min_target_erosion_size)?
+                    erode_cigar_start(
+                        &next.cigar_ops,
+                        min_query_erosion_size,
+                        min_target_erosion_size,
+                    )?
                 }
             } else {
                 (next.cigar_ops.clone(), 0, 0)
@@ -534,7 +549,7 @@ fn process_chain(
         } else if query_gap == 0 && target_gap > 0 {
             // Target gap only - add deletion
             vec![CigarOp('D', target_gap as usize)]
-        } else { 
+        } else {
             // Both query and target have gaps - perform alignment
             let gap_query_seq = query_db.get_subsequence(
                 &current.query_name,


### PR DESCRIPTION
This avoids converting the representation for cigar strings multiple times.